### PR TITLE
Fix typo in compose-zh-cn.md

### DIFF
--- a/docs/pages.md
+++ b/docs/pages.md
@@ -119,4 +119,4 @@ layout: timeline
 ```
 >`title` 可修改，`layout` 不可修改。
 
-如果想添加「标签云」页面的入口，请参考 [独立页面](/intro/#pages)。
+如果想添加「时间轴」页面的入口，请参考 [独立页面](/intro/#pages)。


### PR DESCRIPTION
`标签云` in line 175 should be `时间轴`. See: [compose-zh-cn.md#175](https://github.com/viosey/material-theme-docs/blame/master/compose-zh-cn.md#L175)